### PR TITLE
fix(deploy): rename vl-tools.config to .mjs

### DIFF
--- a/vl-tools.config.mjs
+++ b/vl-tools.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   favicon: {
     appName: 'Vit Bokisch',
     appShortName: 'Vit Bokisch',


### PR DESCRIPTION
## Summary

Deploy was failing on `bun run make:favicon` after the `@vitus-labs/tools-*` 1.7 → 2.x bump:

```
TypeError: icons.map is not a function
    at generateFavicons (.../tools-favicon/lib/generateFavicon.js:17:52)
```

`@vitus-labs/tools-core` 2.x only resolves `vl-tools.config.mjs` (ESM). The existing `vl-tools.config.js` (CommonJS) was silently ignored, leaving the base config in place where `icons` is a per-platform options object — not the array of `{ input, output, path }` entries the CLI expects.

## Changes

- Rename `vl-tools.config.js` → `vl-tools.config.mjs`
- `module.exports = { ... }` → `export default { ... }`

## Test plan

- [x] `bun run make:favicon` exits 0 locally and regenerates `public/favicon/{light,dark}/`
- [ ] CI deploy step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)