### PR TITLE
chore: bump @vitus-labs to 2.0.0-beta.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "@vitbokisch/personal-web",
       "dependencies": {
-        "@vitus-labs/connector-styler": "2.0.0-beta.3",
-        "@vitus-labs/coolgrid": "2.0.0-beta.3",
-        "@vitus-labs/core": "2.0.0-beta.3",
-        "@vitus-labs/elements": "2.0.0-beta.3",
-        "@vitus-labs/hooks": "2.0.0-beta.3",
-        "@vitus-labs/rocketstyle": "2.0.0-beta.3",
-        "@vitus-labs/styler": "2.0.0-beta.3",
-        "@vitus-labs/unistyle": "2.0.0-beta.3",
+        "@vitus-labs/connector-styler": "2.0.0-beta.4",
+        "@vitus-labs/coolgrid": "2.0.0-beta.4",
+        "@vitus-labs/core": "2.0.0-beta.4",
+        "@vitus-labs/elements": "2.0.0-beta.4",
+        "@vitus-labs/hooks": "2.0.0-beta.4",
+        "@vitus-labs/rocketstyle": "2.0.0-beta.4",
+        "@vitus-labs/styler": "2.0.0-beta.4",
+        "@vitus-labs/unistyle": "2.0.0-beta.4",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -122,19 +122,19 @@
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
-    "@vitus-labs/connector-styler": ["@vitus-labs/connector-styler@2.0.0-beta.3", "", { "peerDependencies": { "@vitus-labs/styler": "2.0.0-beta.3", "react": ">= 19" } }, "sha512-fR6+Isk+00gKGs39Az/feJsiWtLE7hnOtWQVpHexh8gQ5b4g1MY732JUIUUkU4E3LfZxDilo01OuXOaHAUZOTQ=="],
+    "@vitus-labs/connector-styler": ["@vitus-labs/connector-styler@2.0.0-beta.4", "", { "peerDependencies": { "@vitus-labs/styler": "2.0.0-beta.4", "react": ">= 19" } }, "sha512-lZr8lP/qDg8Z/81tCCHhiS2+aH6OSmtASqgXcUBT3NL/ndTFecaeW+/0+2yJ/Mny2kedq7IorTKpjja3+hdNog=="],
 
-    "@vitus-labs/coolgrid": ["@vitus-labs/coolgrid@2.0.0-beta.3", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.3", "@vitus-labs/unistyle": "2.0.0-beta.3", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-Ob50683eCQXX0/v7Fv27T8qHV3/pYzEc4ZJRXWzAYsqQ2awnQ29ONC3uW6stpobJt/2yNC7rpvjhgAHc9KzmvA=="],
+    "@vitus-labs/coolgrid": ["@vitus-labs/coolgrid@2.0.0-beta.4", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.4", "@vitus-labs/unistyle": "2.0.0-beta.4", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-e3qc8pbUkrIEQD4ozjj7i6jKh6PZ1EkZVUZLqy2sBd+mwcCe7Hrx76RgJV10y0zjle1gHfbnYFH+SEh6wKk/PA=="],
 
-    "@vitus-labs/core": ["@vitus-labs/core@2.0.0-beta.3", "", { "dependencies": { "react-is": "^19.2.4" }, "peerDependencies": { "react": ">= 19" } }, "sha512-7dP9Futkv4bzlIy1FcDISEmQSVNZmvnaJq0llClsR8Nr96tJVIXLCqyAcfTCmbkDt1qYH42FX+yr2wtoc17mkQ=="],
+    "@vitus-labs/core": ["@vitus-labs/core@2.0.0-beta.4", "", { "dependencies": { "react-is": "^19.2.4" }, "peerDependencies": { "react": ">= 19" } }, "sha512-xTtlxfimk0W2FR7P03pBnb8X+k6wwxDVK/6GURgEG6TOnzhGnUY3D6wu0DNTL3Nqg+TmtStSfh3qidLoKyjbGQ=="],
 
-    "@vitus-labs/elements": ["@vitus-labs/elements@2.0.0-beta.3", "", { "dependencies": { "react-is": "^19.2.4" }, "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.3", "@vitus-labs/unistyle": "2.0.0-beta.3", "react": ">= 19", "react-dom": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-dom", "react-native"] }, "sha512-3CBB53JYEnuFNWpDlclTE1+TPaM5IQvEy+ayfpXQ4d00TOQl2XqXrm8UVOdAuMeZ/gFANbHovN6w5hKDA/DU/Q=="],
+    "@vitus-labs/elements": ["@vitus-labs/elements@2.0.0-beta.4", "", { "dependencies": { "react-is": "^19.2.4" }, "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.4", "@vitus-labs/unistyle": "2.0.0-beta.4", "react": ">= 19", "react-dom": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-dom", "react-native"] }, "sha512-TEgTs5g7nRuPg+qjOUDJl0tzUoTtuK2BTekY5g4bsQAfWZaDdaf55gITYtwrDIi684IigUu0jAqjehc5kSUfbw=="],
 
-    "@vitus-labs/hooks": ["@vitus-labs/hooks@2.0.0-beta.3", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.3", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-kVzfwdT8+Z3AtJlqobtw5GAl3t5nqyAVLpbMjUujRDn+w7MMheIDEFuRNu6QsTOs0MsORzZak0a9QiyBqVjy6w=="],
+    "@vitus-labs/hooks": ["@vitus-labs/hooks@2.0.0-beta.4", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.4", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-muLz3HetP7sF2Agh+k9EqE/Ffw63dcl9ZSt49NwFEbWWr5KtWbNN5r8yAnxq4tEOP2FR0ql9xbpBbIAHZBs/hA=="],
 
-    "@vitus-labs/rocketstyle": ["@vitus-labs/rocketstyle@2.0.0-beta.3", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.3", "react": ">= 19" } }, "sha512-1oCQ+v0EpUdwcNkymcxIDF9NJi98GPXYuEmfPpYauBeXjXKGIoHQOEwyn8FG6HPWChix72QtWttgG3HN2a2jIw=="],
+    "@vitus-labs/rocketstyle": ["@vitus-labs/rocketstyle@2.0.0-beta.4", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.4", "react": ">= 19" } }, "sha512-+w0V1BMv54wqMAIFn7mFXxklSxWXvI4fOP+Hy2PBneakjtBNu3u+m4dgHmH3eEuUHGxJqeoEgpDcyEDWDgfUYA=="],
 
-    "@vitus-labs/styler": ["@vitus-labs/styler@2.0.0-beta.3", "", { "peerDependencies": { "react": ">= 19" } }, "sha512-EGZjKtRH14WJ9MVn+HLN5r3/n4MR/0IKR5lQTIPoIsaqsLv/saZFaSqWcLsFpea4Xz3NBei1D9Ak6W0DXjgWiQ=="],
+    "@vitus-labs/styler": ["@vitus-labs/styler@2.0.0-beta.4", "", { "peerDependencies": { "react": ">= 19" } }, "sha512-gehI3PGm5IE0Noi9IM+J7yaO14cGEQyM6ukDeFU0wTqoSn8mBtpS3jlpsuNClpSJVMJKiZfiU3KcR+y1OQr80g=="],
 
     "@vitus-labs/tools-core": ["@vitus-labs/tools-core@2.1.0", "", {}, "sha512-SaSRQMXD+KsTxeE56qrsIPljZeb/mg1IeA6C7JDNU6upqPGXcUlVjt9FPLU0p7OXcLrBR62Yl3NZsdMGKIh1EQ=="],
 
@@ -142,7 +142,7 @@
 
     "@vitus-labs/tools-typescript": ["@vitus-labs/tools-typescript@2.3.0", "", { "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-QQ9BRHqjloTJh6cGZq3U2AXnsarWaZB2qpSTyAf8vKWkvJDjes1KrxGPMkBXMAYX1Dmjm7gCzS3wvaNp/T2hhA=="],
 
-    "@vitus-labs/unistyle": ["@vitus-labs/unistyle@2.0.0-beta.3", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.3", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-+SjeSefl91fnMak3J7WCqFQX7dR/s8SWVydHUYyIgJL2Rd1CLM4Lt1HhSeV6TRJtswJ9cDOm3ShzsKMJG0daSg=="],
+    "@vitus-labs/unistyle": ["@vitus-labs/unistyle@2.0.0-beta.4", "", { "peerDependencies": { "@vitus-labs/core": "2.0.0-beta.4", "react": ">= 19", "react-native": ">= 0.76" }, "optionalPeers": ["react-native"] }, "sha512-tbpT3Hz6PqEgoy3ObyonOZ2xlKsM+H85qOSThX8Utyz3bkIA/JPw2EVCz2p0Hz/odYCvfpdenbX7mBA2lMbjEA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "make:favicon": "bun run vl_favicon"
   },
   "dependencies": {
-    "@vitus-labs/connector-styler": "2.0.0-beta.3",
-    "@vitus-labs/styler": "2.0.0-beta.3",
-    "@vitus-labs/coolgrid": "2.0.0-beta.3",
-    "@vitus-labs/core": "2.0.0-beta.3",
-    "@vitus-labs/elements": "2.0.0-beta.3",
-    "@vitus-labs/hooks": "2.0.0-beta.3",
-    "@vitus-labs/rocketstyle": "2.0.0-beta.3",
-    "@vitus-labs/unistyle": "2.0.0-beta.3",
+    "@vitus-labs/connector-styler": "2.0.0-beta.4",
+    "@vitus-labs/styler": "2.0.0-beta.4",
+    "@vitus-labs/coolgrid": "2.0.0-beta.4",
+    "@vitus-labs/core": "2.0.0-beta.4",
+    "@vitus-labs/elements": "2.0.0-beta.4",
+    "@vitus-labs/hooks": "2.0.0-beta.4",
+    "@vitus-labs/rocketstyle": "2.0.0-beta.4",
+    "@vitus-labs/unistyle": "2.0.0-beta.4",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"


### PR DESCRIPTION
## Summary

Bumps all `@vitus-labs/*` framework packages from beta.3 → **beta.4**.

## Verification

- [x] `bun install`
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run linter` — 0 errors (2 pre-existing `any` warnings)
- [x] `bun run build` — succeeds, prerenders `/` and `/resume`

🤖 Generated with [Claude Code](https://claude.com/claude-code)