### PR TITLE
perf(font): drop unused italic Ubuntu weights (-12 woff2 files)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,7 @@ export default defineConfig({
       // Auto-wired (0.30.0+): folds imagePlugin + fontPlugin config
       // into zero() — no separate plugin calls needed.
       image: { widths: [480, 768, 1024], formats: ['webp'], quality: 80 },
-      font: { google: ['Ubuntu:ital,wght@0,300;0,500;1,300;1,500'], display: 'swap' },
+      font: { google: ['Ubuntu:wght@300;500'], display: 'swap' },
     }),
     analyze &&
       visualizer({


### PR DESCRIPTION
## Summary

One-line config change. `fontPlugin` was shipping italic Ubuntu (4 weight/style combos × 6 unicode subsets = 24 files) but **italic never renders on any visible page** — `<Text italic>` + `<Quote>` declare the styling but no component instance is ever in the live tree.

```diff
- font: { google: ['Ubuntu:ital,wght@0,300;0,500;1,300;1,500'], display: 'swap' },
+ font: { google: ['Ubuntu:wght@300;500'], display: 'swap' },
```

## Effect

| | Before | After |
|---|---:|---:|
| woff2 files emitted | 24 | **12** |
| `dist/assets/fonts/` disk | 144 KB | **72 KB** |
| Fonts fetched on first paint | 4 | **3** |
| Italic content rendering | n/a (none on page) | n/a (none on page) |

If anyone ever adds italic content later, the browser falls back to faux-italic from the regular Ubuntu — visually fine, no FOIT, no FOUT shift.

## Pyreon-side follow-up (filed separately)

`fontPlugin` has no `subsets` config — it always emits all 6 unicode subsets (Cyrillic, Greek, etc.) even for Latin-only sites. The other 12 woff2 files we ship are never fetched by the browser (`unicode-range` skips them) but still consume disk + CI build time. Tracking upstream as a config-option request.

## Verification

- [x] `tsc --noEmit` clean
- [x] `pyreon-lint + oxlint` clean
- [x] `bun run build` clean — 12 woff2 emitted, no italic faces
- [x] Browser preview: title correct, 3 fonts fetched (Latin × 2 weights + Latin-Ext × 1 weight), Ubuntu loaded, 0 JS errors
- [x] `document.fonts` shows 0 italic faces (was: 8+ italic faces previously declared but unused)

## Test plan

- [x] Local verification above
- [ ] CI green
- [ ] Production PageSpeed re-run after merge — `Network dependency tree` parallel font batch goes 4 → 3 fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)