### PR TITLE
fix(favicon): swap light/dark sources so chip matches browser theme

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
     // webmanifest) from a single source pair, and auto-inject the
     // theme-aware <link>s + favicon-toggle script.
     faviconPlugin({
-      source: 'src/assets/favicon/light.svg',
-      darkSource: 'src/assets/favicon/dark.svg',
+      source: 'src/assets/favicon/dark.svg',
+      darkSource: 'src/assets/favicon/light.svg',
       themeColor: '#ffffff',
       backgroundColor: '#ffffff',
     }),


### PR DESCRIPTION
## Summary

Each mode now uses the favicon whose square chip **matches** the browser theme — letters provide the contrast.

| Theme | Before | After |
|---|---|---|
| Light | dark chip + white letters | **white chip + dark letters** |
| Dark | white chip + dark letters | **dark chip + white letters** |

Source SVGs untouched. Single config change swaps `source` ↔ `darkSource` in `faviconPlugin`.

## Verification

- [x] `bun run build` clean
- [x] Static HTML emits correct `<link>` order: `data-favicon-theme="light"` references `favicon-light.svg` (which now has white chip), `data-favicon-theme="dark"` references `favicon-dark.svg` (dark chip)
- [x] Browser auto-switches between the two via the `[data-favicon-theme]` runtime swapper from `faviconPlugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)