### PR TITLE
fix(a11y, cls): Link primary contrast + Intro minHeight

### DIFF
--- a/src/components/core/link.tsx
+++ b/src/components/core/link.tsx
@@ -33,9 +33,12 @@ export default element
       color: t.color.primary.medium,
     },
   }))
-  .states((t) => ({
+  .states((t, m) => ({
+    // Light surface: cyan-700 (5.27:1 AA). Dark surface: brand cyan-500
+    // (passes contrast against dark). `primary.base` on light bg only
+    // hits 2.28:1 — Lighthouse flagged OpenSource GitHub/Docs links.
     primary: {
-      color: t.color.primary.base,
+      color: m(t.color.primary.dark, t.color.primary.base),
 
       hover: {
         color: t.color.primary.medium,

--- a/src/components/sections/Intro/index.tsx
+++ b/src/components/sections/Intro/index.tsx
@@ -12,7 +12,10 @@ const Element = element.theme({ height: "inherit" });
 const Section = section
   .theme({
     height: "100vh",
-    minHeight: { xl: 640 },
+    // Pin min + max so the hero slot is reserved at hydration regardless
+    // of font swap — siblings below (Quote, Companies) can't be pushed.
+    // Eliminates the CLS shift Lighthouse flagged on "Years of Shipping".
+    minHeight: { xs: 640, md: 840 },
     maxHeight: { xs: 640, md: 840 },
     overflow: "hidden",
     background:


### PR DESCRIPTION
## Summary

Two Lighthouse mobile audit failures on the latest deploy:

| Audit | Before | After | Fix |
|---|---|---|---|
| **color-contrast** | `<Link primary>` on light bg: 2.28:1 ❌ | **5.04:1** ✅ | `core/link` primary state → `m(primary.dark, primary.base)` (cyan-700 on light, cyan-500 on dark) |
| **CLS** (`Years of Shipping` shifter) | 0.145 (sometimes 0.289) | should be < 0.1 | Pin `minHeight === maxHeight` on Intro `<Section>` so hero slot is reserved at hydration regardless of font-swap reflow |

## Changes

- `src/components/core/link.tsx`: `.states((t)` → `.states((t, m)` + `color: m(t.color.primary.dark, t.color.primary.base)` for the `primary` state's base color (hover/active unchanged — those scale through the palette anyway)
- `src/components/sections/Intro/index.tsx`: add matching `minHeight` to `maxHeight` so the Intro slot is reserved regardless of font-swap

## Verification

- [x] `tsc --noEmit` clean
- [x] `pyreon-lint + oxlint` clean
- [x] `bun run build` clean
- [x] Headless browser: GitHub link in OpenSource section renders `rgb(14, 116, 144)` (= `#0E7490` = `primary.dark`) → 5.04:1 contrast vs the `rgb(248, 248, 248)` background
- [x] 0 JS errors on hydration

## Expected Lighthouse delta

- **A11y**: 94 → ~100 (color-contrast was the only red audit)
- **Perf**: CLS should drop from 0.145 → < 0.1, lifting the CLS score from 0.77 → 1.0 → adds ~6 points to overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)