### PR TITLE
fix(intro): cap fullScreen variant max height so hero fits viewport

### DIFF
--- a/src/components/sections/Intro/index.tsx
+++ b/src/components/sections/Intro/index.tsx
@@ -24,8 +24,12 @@ const Section = section
   .variants(() => ({
     fullScreen: {
       height: "100vh",
-      minHeight: { xs: 640, md: 800, lg: 1400 },
-      maxHeight: { xs: 640, md: 800, lg: 1400 },
+      // Keep hero within viewport at lg+ — the previous `lg: 1400` made
+      // the section taller than typical laptop viewports (1440x900 has
+      // ~820px of usable height after browser chrome), pushing the
+      // content + profile photo below the fold on the homepage.
+      minHeight: { xs: 640, md: 800 },
+      maxHeight: { xs: 640, md: 800 },
     },
   }));
 


### PR DESCRIPTION
## Why

Homepage hero on `lg+` viewports was taller than the viewport itself, pushing HELLO text + profile photo below the fold.

Deployed prod screenshot at 1440×~800 laptop:
- Just "Vit Bokisch" header at top
- Vast empty gradient middle
- HELLO + profile photo cut off at the bottom
- Half the hero content invisible without scrolling

## Root cause

`src/components/sections/Intro/index.tsx` — `fullScreen` variant had:

```ts
minHeight: { xs: 640, md: 800, lg: 1400 },
maxHeight: { xs: 640, md: 800, lg: 1400 },
```

At `lg` (992px+ viewport width), the section was **pinned to exactly 1400px tall**. Typical laptop viewports (1440×900) have ~800-820px usable height after browser chrome. Section extended 500+ pixels beyond the fold.

## Fix

Drop the `lg` entry — cap at `md: 800` for all viewports lg+. Simple one-line edit:

```diff
- minHeight: { xs: 640, md: 800, lg: 1400 },
- maxHeight: { xs: 640, md: 800, lg: 1400 },
+ minHeight: { xs: 640, md: 800 },
+ maxHeight: { xs: 640, md: 800 },
```

## Verified (local build + puppeteer)

| Viewport | Section height | Fits? |
|---|---|---|
| 412×823 (mobile) | 640 | ✅ |
| 1440×900 (laptop) | 800 | ✅ |
| 1920×1080 (desktop HD) | 800 | ✅ |

Screenshot at 1440×900 now shows everything within the fold: header top, HELLO + description + contact list on left, profile photo prominent on right, section ends cleanly above the next section band.

## Scope

- Only affects `<Intro variant="fullScreen">` (used on the home page only — `/resume` uses the base variant which is unchanged)
- No effect on mobile (was already `xs: 640`)
- No effect on tablet md (was already `md: 800`)
- Only the lg breakpoint changes: 1400 → 800

## Not touched (intentionally)

- CLS `contain-intrinsic-size` on Section (still emits — verified in earlier PRs)
- ProfileImageWrapper dims (already fixed in PR #48)
- Pyreon version (this fix is site-side, works on 0.49.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)