### PR TITLE
fix(intro): use 100dvh so hero fills viewport at any size

### DIFF
--- a/src/components/sections/Intro/index.tsx
+++ b/src/components/sections/Intro/index.tsx
@@ -23,13 +23,14 @@ const Section = section
   })
   .variants(() => ({
     fullScreen: {
-      height: "100vh",
-      // Keep hero within viewport at lg+ — the previous `lg: 1400` made
-      // the section taller than typical laptop viewports (1440x900 has
-      // ~820px of usable height after browser chrome), pushing the
-      // content + profile photo below the fold on the homepage.
-      minHeight: { xs: 640, md: 800 },
-      maxHeight: { xs: 640, md: 800 },
+      // Dynamic viewport height — fills the visible viewport at any size,
+      // smoothly adjusts when mobile URL bar collapses (no scroll-driven
+      // hero jump like `100vh` produces).
+      height: "100dvh",
+      maxHeight: "100dvh",
+      // Floor for tight landscape phones (~375px tall) so HELLO +
+      // description + contacts stay breathable instead of cramping.
+      minHeight: 640,
     },
   }));
 


### PR DESCRIPTION
## Summary

Replace the pixel-based min/maxHeight on the `fullScreen` variant with **dynamic viewport height (`100dvh`)** plus a floor for very short landscape phones. The hero now fills the visible viewport at any device size — no more empty space above the fold on big monitors, no hero-jump when mobile URL bars collapse.

## The change

```diff
 fullScreen: {
-  height: "100vh",
-  minHeight: { xs: 640, md: 800 },
-  maxHeight: { xs: 640, md: 800 },
+  height: "100dvh",
+  maxHeight: "100dvh",
+  minHeight: 640,
 },
```

## Why `dvh` not `vh`

- `100vh` = viewport when the URL bar is collapsed → hero JUMPS when browser chrome hides/shows as you scroll on mobile
- `100dvh` = current visible viewport → adjusts smoothly, no jump

## Why the 640px floor

Landscape mobile can be ~375px tall. Without a floor, HELLO + description + contact list get cramped. 640 preserves composition; the small extra (~265px) scroll on landscape phones is a fair tradeoff.

## Verified section height across viewports

| Viewport | Section height | Result |
|---|---|---|
| 412×823 (mobile portrait) | 823px | ✓ matches viewport |
| 667×375 (mobile landscape, very short) | 640px | floor active — intentional |
| 1440×900 (typical laptop) | 900px | ✓ matches viewport |
| 1920×1080 (desktop HD) | 1080px | ✓ matches viewport |
| 1080×1920 (vertical monitor) | 1920px | ✓ matches viewport |

Screenshot at 1440×900 shows: header top, HELLO + description + contact icons on left, profile photo prominent on right, contact list at bottom — everything within the fold, beautifully balanced.

## Browser support

`dvh` unit is supported in:
- Chrome 108+ (Oct 2022)
- Safari 15.4+ (Mar 2022)
- Firefox 101+ (May 2022)

The project's `browserslist` targets "last 2 versions of Chrome/Firefox/Safari/Edge" — well within support.

## Not touched

- `contain-intrinsic-size` on base Section (still emits for CLS)
- ProfileImageWrapper dims (fixed in PR #48)
- Base variant (non-fullScreen used on /resume — unchanged, `xs: 640, md: 840` still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)